### PR TITLE
Changed from site_url to home_url

### DIFF
--- a/topdash.php
+++ b/topdash.php
@@ -113,7 +113,7 @@ class Topdash {
             array(
                 'id' => 'topdash_external',
                 'title' => __( '<span class="dashbar-icon dashbar-icon--external"></span>' ),
-                'href' => site_url( )
+                'href' => home_url( )
             )
         );
 


### PR DESCRIPTION
I believe this is more safe if you have installed wordpress in a separate directory. 

e.g. I'm storing wordpress files in `/wp` so when clicking the topdash external link I'm ending up at `url.com/wp`. Changing from `site_url()` to `home_url()` fixes the problem.
